### PR TITLE
add custom slider, some initial styling

### DIFF
--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	import type { Section } from '$lib/types';
+
+	export let value: number;
+	export let section: Section;
+	export let index: number;
+	export let scrollToSection: (evt: Event, idx: number) => void;
+	export let resultsLink: string | null; // Only used for final section
+</script>
+
+<div class="wrapper">
+	<label for={section.key}>{section.dynamic}</label>
+
+	<div class="input-wrapper">
+		<!-- hiding the displayed value and min/max numbers for screenreader, as those are accessible via the input element itself -->
+		<div aria-hidden="true" class="value">{value}</div>
+		<div class="slider">
+			<span aria-hidden="true">1</span>
+			<input
+				bind:value
+				name={section.key}
+				id={section.key}
+				type="range"
+				min="1"
+				max="5"
+				aria-valuemin="1"
+				aria-valuemax="5"
+				aria-valuenow={value}
+			/>
+			<span aria-hidden="true">5</span>
+		</div>
+		<!-- supplementing min/max descriptions with associated numbers for screen reader -->
+		<div class="descriptions">
+			<div><span class="visually-hidden">1 = </span>not true for me</div>
+			<div><span class="visually-hidden">5 = </span>extremely true for me</div>
+		</div>
+	</div>
+
+	<div class="prev-next">
+		{#if index > 0}
+			<a href={`#section-${index - 1}`} onclick={(e) => scrollToSection(e, index - 1)}>
+				Previous
+			</a>
+		{/if}
+		{#if !resultsLink}
+			<a href={`#section-${index + 1}`} onclick={(e) => scrollToSection(e, index + 1)}> Next </a>
+		{/if}
+	</div>
+
+	{#if resultsLink}
+		<div class="finish">
+			<a class="btn secondary" href={resultsLink}>Finish</a>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.wrapper {
+		max-width: 100%;
+		width: var(--width-small);
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+	}
+
+	label {
+		display: block;
+		font-weight: bold;
+		font-size: 1.3rem;
+	}
+
+	.input-wrapper {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		margin: 1rem 0;
+	}
+
+	.value {
+		font-size: 1.3rem;
+	}
+
+	.slider {
+		display: flex;
+		align-items: center;
+	}
+
+	.descriptions {
+		display: flex;
+		justify-content: space-between;
+		color: var(--moss);
+	}
+
+	.prev-next {
+		width: 100%;
+		display: flex;
+		gap: 10px;
+	}
+
+	.finish {
+		width: 100%;
+		display: flex;
+		justify-content: center;
+		margin-top: 2rem;
+	}
+
+	input[type='range'] {
+		appearance: none;
+		-webkit-appearance: none;
+		width: 100%;
+		background: transparent;
+		margin: 0px 1rem;
+		height: 2px;
+		display: flex;
+		background: var(--charcoal);
+		cursor: pointer;
+	}
+
+	/* Chrome, Safari, Opera, Edge */
+	input[type='range' i]::-webkit-slider-thumb {
+		height: 30px;
+		aspect-ratio: 1;
+		border-radius: 50%;
+		border: 2px solid #fff;
+		box-shadow: 0px 2px 6px 1px rgba(0, 0, 0, 0.2);
+		background-color: var(--rust);
+		-webkit-appearance: none;
+		appearance: none;
+	}
+
+	/* Firefox */
+	input[type='range']::-moz-range-thumb {
+		height: 25px;
+		width: 25px;
+		background: none;
+		border-radius: 50%;
+		border: 2px solid #fff;
+		box-shadow: 0px 2px 6px 1px rgba(0, 0, 0, 0.2);
+		background-color: var(--rust);
+		-moz-appearance: none;
+		appearance: none;
+	}
+</style>

--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -74,12 +74,12 @@
 		width: 100%;
 		display: flex;
 		flex-direction: column;
-		gap: 1rem;
-		margin: 1rem 0;
+		gap: 1.5rem;
+		margin: 1.5rem 0;
 	}
 
 	.value {
-		font-size: 1.3rem;
+		font-size: 1.2rem;
 	}
 
 	.slider {

--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -4,7 +4,7 @@
 	export let value: number;
 	export let section: Section;
 	export let index: number;
-	export let scrollToSection: (evt: Event, idx: number) => void;
+	export let handleSectionChange: (evt: Event, idx: number) => void;
 	export let resultsLink: string | null; // Only used for final section
 </script>
 
@@ -17,7 +17,7 @@
 		<div class="slider">
 			<span aria-hidden="true">1</span>
 			<input
-				bind:value
+				bind:value={section.value}
 				name={section.key}
 				id={section.key}
 				type="range"
@@ -38,12 +38,14 @@
 
 	<div class="prev-next">
 		{#if index > 0}
-			<a href={`#section-${index - 1}`} onclick={(e) => scrollToSection(e, index - 1)}>
+			<a href={`#section-${index - 1}`} onclick={(e) => handleSectionChange(e, index - 1)}>
 				Previous
 			</a>
 		{/if}
 		{#if !resultsLink}
-			<a href={`#section-${index + 1}`} onclick={(e) => scrollToSection(e, index + 1)}> Next </a>
+			<a href={`#section-${index + 1}`} onclick={(e) => handleSectionChange(e, index + 1)}>
+				Next
+			</a>
 		{/if}
 	</div>
 

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -1,0 +1,67 @@
+:root {
+	/* AWCS brand guide colors */
+	--moss: #656b4a;
+	--cream: #fffaf5;
+	--charcoal: #303326;
+	--rust: #cc6600;
+	--mustard: #eda618;
+	--sky: #d8e3e5;
+	--blossom: #f9e4e7;
+
+	/* Some guideline widths - happy to adjust! */
+	--width-large: 900px;
+	--width-small: 450px;
+}
+
+body {
+	/* Replace with brand guide typography */
+	font-family: Arial, Helvetica, sans-serif;
+	color: var(--charcoal);
+	background-color: var(--cream);
+	margin: 0px;
+}
+
+/* Class to visually hide element, but keep it available for screen readers.
+   https://www.a11yproject.com/posts/how-to-hide-content/ */
+.visually-hidden {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+}
+
+a {
+	color: var(--mustard);
+	font-weight: bold;
+}
+
+.btn {
+	font-weight: bold;
+	text-decoration: none;
+	border-radius: 2rem;
+	padding: 1rem 2rem;
+	transition: background-color 0.1s linear;
+}
+
+.btn.primary {
+	border: 1px solid var(--charcoal);
+	color: var(--charcoal);
+	background-color: var(--mustard);
+}
+
+.btn.primary:hover {
+	background-color: var(--cream);
+}
+
+.btn.secondary {
+	border: 1px solid var(--charcoal);
+	color: var(--charcoal);
+	background-color: var(--cream);
+}
+
+.btn.secondary:hover {
+	background-color: var(--mustard);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,6 @@
+export interface Section {
+	key: string;
+	dynamic: string;
+	el: HTMLElement | undefined;
+	value: number;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import '$lib/styles/app.css';
+</script>
+
+<slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-	let { data } = $props();
+	import PromptWithSlider from '$lib/components/PromptWithSlider.svelte';
+	import type { Section } from '$lib/types';
 
-	interface Section {
-		key: string;
-		dynamic: string;
-		el: HTMLElement | undefined;
-		value: number;
-	}
+	let { data } = $props();
 
 	const sections: Section[] = $state(
 		data.dynamics.map((dynamic, idx) => {
@@ -46,46 +42,32 @@
 </svelte:head>
 
 <main>
-	<section>
-		<h1>8 Dynamics of Climate Engagement</h1>
-		<p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce lobortis mi arcu, sed iaculis
-			sapien sodales sit amet. Vestibulum magna urna, laoreet vitae ante et, lobortis laoreet justo.
-			Aliquam erat volutpat. Quisque commodo, ex non bibendum commodo, nulla nisi posuere enim, ut
-			hendrerit tellus tortor sed sem. Maecenas sollicitudin tortor et orci porta pharetra. Sed eget
-			nisi facilisis, ultricies tortor et, accumsan mi. Aenean lobortis et odio vitae mollis. Nullam
-			porttitor, magna ut feugiat suscipit, massa enim congue quam, ultricies tincidunt velit mauris
-			a dui. Pellentesque accumsan felis pellentesque, tempus odio at, venenatis nulla.
-		</p>
-		<a href="#section-0" onclick={(e) => scrollToSection(e, 0)}>Start</a>
+	<section class="intro">
+		<div>
+			<h1>8 Dynamics of Climate Engagement</h1>
+			<p>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce lobortis mi arcu, sed iaculis
+				sapien sodales sit amet. Vestibulum magna urna, laoreet vitae ante et, lobortis laoreet
+				justo. Aliquam erat volutpat. Quisque commodo, ex non bibendum commodo, nulla nisi posuere
+				enim, ut hendrerit tellus tortor sed sem. Maecenas sollicitudin tortor et orci porta
+				pharetra. Sed eget nisi facilisis, ultricies tortor et, accumsan mi. Aenean lobortis et odio
+				vitae mollis. Nullam porttitor, magna ut feugiat suscipit, massa enim congue quam, ultricies
+				tincidunt velit mauris a dui. Pellentesque accumsan felis pellentesque, tempus odio at,
+				venenatis nulla.
+			</p>
+			<a class="btn primary" href="#section-0" onclick={(e) => scrollToSection(e, 0)}>Start</a>
+		</div>
 	</section>
 
 	{#each sections as section, index}
-		<!-- TODO: make this a component -->
 		<section id={`section-${index}`} bind:this={section.el}>
-			<label for={section.key}>{index + 1}. {section.dynamic}</label>
-			<input
-				name={section.key}
-				id={section.key}
-				type="range"
-				min="1"
-				max="5"
+			<PromptWithSlider
 				bind:value={section.value}
+				{section}
+				{index}
+				{scrollToSection}
+				resultsLink={index === sections.length - 1 ? resultsLink : null}
 			/>
-			<div class="buttons">
-				{#if index > 0}
-					<a href={`#section-${index - 1}`} onclick={(e) => scrollToSection(e, index - 1)}>
-						Previous
-					</a>
-				{/if}
-				{#if index === sections.length - 1}
-					<a href={resultsLink}>Finish</a>
-				{:else}
-					<a href={`#section-${index + 1}`} onclick={(e) => scrollToSection(e, index + 1)}>
-						Next
-					</a>
-				{/if}
-			</div>
 		</section>
 	{/each}
 </main>
@@ -98,11 +80,26 @@
 		scroll-behavior: smooth;
 	}
 	section {
+		padding: 2rem;
 		height: 100vh;
+		box-sizing: border-box;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-direction: column;
 		scroll-snap-align: start;
 		scroll-padding: 2em;
 	}
-	label {
-		display: block;
+	section.intro {
+		background-color: var(--sky);
+	}
+	section.intro > div {
+		width: var(--width-large);
+		text-align: center;
+		max-width: 100%;
+	}
+	.intro p {
+		text-align: left;
+		padding: 1rem 0px;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,7 +65,7 @@
 				bind:value={section.value}
 				{section}
 				{index}
-				{scrollToSection}
+				handleSectionChange={scrollToSection}
 				resultsLink={index === sections.length - 1 ? resultsLink : null}
 			/>
 		</section>


### PR DESCRIPTION
Here's a shot at a component for the prompts and sliders!

Related to this component, I also added an initial `app.css` file with the AWCS brand kit colors as CSS variables and some other shareable classes.

Not attached to any particular way I have things organized (e.g. this component living in a "$lib/components" folder), so please let me know if anyone has a preference. For CSS, I realize I tend to use `rem`, but open to other standards for sizing.

Styling is definitely not complete (need fonts, chose brand colors at random, mentimeter includes various colors for the buttons, etc.), but hope that this gives a good baseline for the custom slider.

Screenshot of slider for PR
<img width="745" alt="Screenshot 2024-10-28 at 4 14 05 PM" src="https://github.com/user-attachments/assets/8ca70e8d-c4f9-40c5-b55c-d0940e7dd7f3">

