### PR TITLE
Update prev/next "button" styles and fix scroll behavior

### DIFF
--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -43,7 +43,11 @@
 			</a>
 		{/if}
 		{#if !resultsLink}
-			<a href={`#section-${index + 1}`} onclick={(e) => handleSectionChange(e, index + 1)}>
+			<a
+				class="next"
+				href={`#section-${index + 1}`}
+				onclick={(e) => handleSectionChange(e, index + 1)}
+			>
 				Next
 			</a>
 		{/if}
@@ -108,6 +112,9 @@
 			padding: 8px;
 			border-radius: 8px;
 			border: 1px solid var(--moss);
+		}
+		.next {
+			margin-left: auto;
 		}
 	}
 

--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -99,6 +99,16 @@
 		width: 100%;
 		display: flex;
 		gap: 10px;
+		justify-content: space-between;
+
+		a {
+			color: var(--moss);
+			font-weight: bold;
+			text-decoration: none;
+			padding: 8px;
+			border-radius: 8px;
+			border: 1px solid var(--moss);
+		}
 	}
 
 	.finish {

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -33,11 +33,6 @@ body {
 	white-space: nowrap;
 }
 
-a {
-	color: var(--mustard);
-	font-weight: bold;
-}
-
 .btn {
 	font-weight: bold;
 	text-decoration: none;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -78,6 +78,7 @@
 		height: 100vh;
 		scroll-snap-type: y mandatory;
 		scroll-behavior: smooth;
+		overscroll-behavior: contain;
 	}
 	section {
 		padding: 2rem;


### PR DESCRIPTION
2 main changes in this PR:

1. `<a />` tag styles for prev/next "buttons": this might mostly be personal preference. While we're using a tags to link to the next section, I felt these made more sense visually as buttons. This is the only opinion I feel even remotely strongly about - open to changes to the styling! See After screen capture for what these look like.
2. Scroll behavior: if users opt to scroll vs use the prev/next buttons, they're able to scroll beyond the last question, and the scroll bar will move to the top of the page. See screen captures for before and after.

Before:
https://github.com/user-attachments/assets/b8c0d6ca-0123-43a4-8cf7-d64293bddaec

After:
https://github.com/user-attachments/assets/5ce41ff5-a22f-4750-b459-68a91d8fe03a

