### PR TITLE
Add focus logic for Safari, update focus styles

### DIFF
--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -74,6 +74,7 @@
 		display: block;
 		font-weight: bold;
 		font-size: 1.3rem;
+		outline: none;
 	}
 
 	.input-wrapper {
@@ -91,6 +92,12 @@
 	.slider {
 		display: flex;
 		align-items: center;
+		padding: 10px 16px;
+		border: 4px solid var(--cream);
+		margin: -14px -20px;
+		border-radius: 28px;
+		transition: border 0.2s linear;
+		box-sizing: border-box;
 	}
 
 	.descriptions {
@@ -135,6 +142,14 @@
 		display: flex;
 		background: var(--charcoal);
 		cursor: pointer;
+	}
+
+	.slider:has(:focus-visible) {
+		border: 4px solid var(--mustard);
+	}
+
+	input[type='range']:focus {
+		outline: none;
 	}
 
 	/* Chrome, Safari, Opera, Edge */

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -33,6 +33,17 @@ body {
 	white-space: nowrap;
 }
 
+button,
+a {
+	transition: outline 0.2s linear;
+	transition-delay: 0.1s;
+}
+
+button:focus,
+a:focus {
+	outline: 4px solid var(--mustard);
+}
+
 .btn {
 	font-weight: bold;
 	text-decoration: none;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,8 +15,6 @@
 		})
 	);
 
-	const onSafari = navigator.userAgent.includes('Safari');
-
 	function scrollToSection(evt: Event, idx: number) {
 		// supercedes the default a tag link for smooth scrolling if javascript is enabled
 		evt.preventDefault();
@@ -29,7 +27,7 @@
 		// Focus the input in the given section once in view, preventing duplicate scrolling.
 		// Unlike other browsers, Safari seems to assume focus-visible on a mouse link click,
 		// so focusing to the section for Safari instead of the input to avoid triggering focus styles for mouse users.
-		const elementIdToFocus = onSafari ? `section-${idx}` : key;
+		const elementIdToFocus = navigator.userAgent.includes('Safari') ? `section-${idx}` : key;
 		document.getElementById(elementIdToFocus)?.focus({ preventScroll: true });
 	}
 
@@ -66,9 +64,9 @@
 	</section>
 
 	{#each sections as section, index}
-		<!-- Allow the section to be focusable for Safari to avoid focus styles being applied to input on link click -->
+		<!-- Allow focus jumping to section to avoid focus styles being applied to input on Safari link click -->
 		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-		<section id={`section-${index}`} tabindex={onSafari ? -1 : null} bind:this={section.el}>
+		<section id={`section-${index}`} tabindex={-1} bind:this={section.el}>
 			<PromptWithSlider
 				bind:value={section.value}
 				{section}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,8 @@
 		})
 	);
 
+	const onSafari = navigator.userAgent.includes('Safari');
+
 	function scrollToSection(evt: Event, idx: number) {
 		// supercedes the default a tag link for smooth scrolling if javascript is enabled
 		evt.preventDefault();
@@ -23,8 +25,12 @@
 		el.scrollIntoView({
 			behavior: 'smooth'
 		});
-		// focus the input in the given section once in view
-		document.getElementById(key)?.focus();
+
+		// Focus the input in the given section once in view, preventing duplicate scrolling.
+		// Unlike other browsers, Safari seems to assume focus-visible on a mouse link click,
+		// so focusing to the section for Safari instead of the input to avoid triggering focus styles for mouse users.
+		const elementIdToFocus = onSafari ? `section-${idx}` : key;
+		document.getElementById(elementIdToFocus)?.focus({ preventScroll: true });
 	}
 
 	const resultsLink = $derived.by(() => {
@@ -60,7 +66,8 @@
 	</section>
 
 	{#each sections as section, index}
-		<section id={`section-${index}`} bind:this={section.el}>
+		<!-- Allow the section to be focusable for Safari to avoid focus styles being applied to input on link click -->
+		<section id={`section-${index}`} tabindex={onSafari ? -1 : 0} bind:this={section.el}>
 			<PromptWithSlider
 				bind:value={section.value}
 				{section}
@@ -90,6 +97,7 @@
 		flex-direction: column;
 		scroll-snap-align: start;
 		scroll-padding: 2em;
+		outline: 0px;
 	}
 	section.intro {
 		background-color: var(--sky);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -67,6 +67,7 @@
 
 	{#each sections as section, index}
 		<!-- Allow the section to be focusable for Safari to avoid focus styles being applied to input on link click -->
+		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 		<section id={`section-${index}`} tabindex={onSafari ? -1 : null} bind:this={section.el}>
 			<PromptWithSlider
 				bind:value={section.value}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -67,7 +67,7 @@
 
 	{#each sections as section, index}
 		<!-- Allow the section to be focusable for Safari to avoid focus styles being applied to input on link click -->
-		<section id={`section-${index}`} tabindex={onSafari ? -1 : 0} bind:this={section.el}>
+		<section id={`section-${index}`} tabindex={onSafari ? -1 : null} bind:this={section.el}>
 			<PromptWithSlider
 				bind:value={section.value}
 				{section}


### PR DESCRIPTION
Fixing buggy-looking focus experience for Safari, and improving focus states across all browsers!

This PR:
- Adds stylized focus for the slider input (see first screenshot)
- Updates focus for buttons and links to share similar styles (see second screenshot)
- Adds `preventScroll: true` to the `focus()` call on the next/prev button clicks, since we are already programmatically scrolling and the duplication was causing some buggy scrolling behavior on Safari and Firefox
- Focuses on the `section` instead of the `input` for Safari (see below)

Browsers these days tend to do some nice checking on whether the user is navigating via keyboard or via mouse to guess when to best show focus states, but there's some variation situationally between browsers. I just tested the site on Firefox, Chrome, Safari, Edge, and Opera, and only Safari is deciding to show the input as focused on the prev/next link clicks. Since I do think this detracts from the mouse-navigation experience, I added a check for Safari browsers and instead focus on the `section` instead of the `input` when on Safari. When screen reader testing using Apple's voice over, the correct section is still read out when you click a link.

<img width="618" alt="Screenshot 2024-11-11 at 4 47 56 PM" src="https://github.com/user-attachments/assets/f8a3bead-f4b3-4ba5-a6f0-9763d668edb1">

<img width="601" alt="Screenshot 2024-11-11 at 4 48 03 PM" src="https://github.com/user-attachments/assets/3e7df6c0-8f79-45f4-aaef-2e3854cafc4e">
