### PR TITLE
add shortened dynamic names

### DIFF
--- a/src/lib/components/SpiderChart.svelte
+++ b/src/lib/components/SpiderChart.svelte
@@ -117,7 +117,12 @@
 			const x = radius * Math.sin(angle);
 			// multiply y by -1 so it maps clockwise
 			const y = radius * Math.cos(angle) * -1;
-			points.push({ offsetX: x, offsetY: y, text: dynamics[i] });
+			points.push({
+				offsetX: x,
+				offsetY: y,
+				fullText: dynamics[i].full,
+				shortText: dynamics[i].short
+			});
 		}
 		return points;
 	});
@@ -155,9 +160,9 @@
 				style={`width: ${config.labelD}px; height: ${config.labelD}px; transform: translate(${label.offsetX}px, ${label.offsetY}px)`}
 			>
 				{#if innerWidth >= BREAKPOINT}
-					{label.text}
+					{label.fullText}
 				{:else}
-					Dynamic {idx + 1}
+					{label.shortText}
 				{/if}
 			</div>
 		{/each}
@@ -208,6 +213,7 @@
 		text-align: center;
 		display: flex;
 		align-items: center;
+		justify-content: center;
 		padding: 1rem;
 		box-sizing: border-box;
 		color: var(--charcoal);

--- a/src/lib/dynamics.ts
+++ b/src/lib/dynamics.ts
@@ -1,11 +1,35 @@
 // Ordering matters here
 export default [
-	'I hold deep motivations to foster a just, life-giving future.',
-	'I feel connected to Earth and kindred community.',
-	'I can see myself in the unfolding, collective climate story.',
-	'I’m able to work with climate emotions and access healing and rest.',
-	'I understand climate truth, just solutions, and leverage points for change.',
-	'I have clarity around my contribution, while embracing its evolution.',
-	'I find footholds for meaningful action and collaboration.',
-	'I have a sense of possibility, authentic power, and joy in the work.'
+	{
+		short: 'Motivation',
+		full: 'I hold deep motivations to foster a just, life-giving future.'
+	},
+	{
+		short: 'Connection',
+		full: 'I feel connected to Earth and kindred community.'
+	},
+	{
+		short: 'Story',
+		full: 'I can see myself in the unfolding, collective climate story.'
+	},
+	{
+		short: 'Emotions',
+		full: 'I’m able to work with climate emotions and access healing and rest.'
+	},
+	{
+		short: 'Understanding',
+		full: 'I understand climate truth, just solutions, and leverage points for change.'
+	},
+	{
+		short: 'Clarity',
+		full: 'I have clarity around my contribution, while embracing its evolution.'
+	},
+	{
+		short: 'Action',
+		full: 'I find footholds for meaningful action and collaboration.'
+	},
+	{
+		short: 'Possibility',
+		full: 'I have a sense of possibility, authentic power, and joy in the work.'
+	}
 ];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 	let { data } = $props();
 
 	const sections: Section[] = $state(
-		data.dynamics.map((dynamic, idx) => {
+		data.dynamics.map(({ full: dynamic }, idx) => {
 			return {
 				key: 'ABCDEFGH'[idx],
 				dynamic,


### PR DESCRIPTION
Converts the array of dynamic strings in `dynamics.ts` to an array of objects with shortened and full text strings, e.g. `{ short: 'Motivation', full: 'I hold deep motivations ...' }` for displaying the one-word dynamic strings on mobile.

<img width="500" alt="Screenshot 2024-11-13 at 3 17 09 PM" src="https://github.com/user-attachments/assets/859020ae-71a8-4f1f-9342-3f207cf34c0b">
