### PR TITLE
Results page: responsiveness

### DIFF
--- a/src/lib/components/SpiderChart.svelte
+++ b/src/lib/components/SpiderChart.svelte
@@ -124,7 +124,7 @@
 					y2={f.outerY}
 				/>
 				<line class="dash" x1={f.outerX} y1={f.outerY} x2={f.labelX} y2={f.labelY} />
-				<g class="label">
+				<g class="label" class:highlight={highlight === idx}>
 					<circle
 						cx={f.labelX}
 						cy={f.labelY}
@@ -188,5 +188,11 @@
 	.label circle {
 		fill: var(--sky);
 		transition: fill 0.2s linear;
+	}
+	.label.highlight circle {
+		fill: black;
+	}
+	.label.highlight text {
+		fill: white;
 	}
 </style>

--- a/src/lib/components/SpiderChart.svelte
+++ b/src/lib/components/SpiderChart.svelte
@@ -175,7 +175,7 @@
 
 	text {
 		/* all <text> elements live inside a circle */
-		transform: translate(-3px, 4px);
+		transform: translate(-4px, 3px);
 	}
 	/* LABELS */
 	.label text {

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -73,11 +73,15 @@ a:focus {
 }
 
 .btn {
+	font-size: 14px;
 	font-weight: 600;
 	text-decoration: none;
 	border-radius: 50px;
 	padding: 16px 30px;
 	transition: all 0.1s linear;
+	/* fixes for discrepancies between .btn on <a> and <button> */
+	font: inherit;
+	text-align: center;
 }
 
 .btn.primary {

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -1,20 +1,60 @@
 <script lang="ts">
 	import SpiderChart from '$lib/components/SpiderChart.svelte';
 	import dynamics from '$lib/dynamics';
+	import { onDestroy, onMount } from 'svelte';
 
-	export let data;
+	const INTERVAL = 1500;
+	let { data } = $props();
+	let highlight = $state(0);
+	let intervalId = $state<number>();
+
+	function rotateSelected() {
+		let selected = highlight + 1;
+		if (selected >= dynamics.length) {
+			selected = 0;
+		}
+		// side-effect
+		highlight = selected;
+	}
+
+	onMount(() => {
+		if (!intervalId) {
+			intervalId = setInterval(rotateSelected, INTERVAL);
+		}
+	});
+	onDestroy(() => {
+		clearInterval(intervalId);
+	});
 </script>
 
 <main>
 	<h1 class="title">Your Results</h1>
 	<div class="chart">
-		<SpiderChart answers={data.object} />
+		<SpiderChart answers={data.object} {highlight} />
 	</div>
-	<ol>
-		{#each dynamics as dynamic}
-			<li>{dynamic.full}</li>
-		{/each}
-	</ol>
+	<div class="results">
+		<ol>
+			{#each dynamics as dynamic, idx}
+				<li class:highlight={idx === highlight}>{dynamic.full}</li>
+			{/each}
+		</ol>
+		<div class="next-steps">
+			<h2>If you have a notebook on hand, jot down your responses.</h2>
+			<ul>
+				<li>Looking at your results, what insights arise for you?</li>
+				<li>
+					Given what feels wobbly and what feels strong, pick one dynamic that might support your
+					own deep, sustained, and courageous climate engagement. How could you invest in it with
+					intention? What support do you need?
+				</li>
+			</ul>
+			<div class="actions">
+				<!-- TODO: add actions and link -->
+				<button class="btn secondary">Email Your Results</button>
+				<a href="#" class="btn secondary">Resources for Support</a>
+			</div>
+		</div>
+	</div>
 </main>
 
 <style>
@@ -23,7 +63,7 @@
 		padding: 3rem;
 		min-height: 100vh;
 		position: relative;
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr minmax(400px, 1fr);
 		grid-template-rows: min-content 1fr;
 		background-image: url('$lib/assets/cloud-1.png'), url('$lib/assets/cloud-4.png'),
 			url('$lib/assets/cloud-5.png');
@@ -39,15 +79,45 @@
 		margin: 0;
 		padding: 0;
 	}
+	h2 {
+		font-family: 'adobe-garamond-pro', serif;
+		font-weight: 400;
+		font-size: 18px;
+		line-height: 1.4;
+		margin-top: 0;
+	}
+	.actions {
+		margin-top: 1.2em;
+		display: flex;
+		gap: 1.5em;
+	}
 	ol {
-		padding: 2em 1em;
-		line-height: 2;
+		padding: 0 1em;
+	}
+	ol li {
+		margin-bottom: 1em;
+	}
+	ul {
+		padding-inline-start: 20px;
+	}
+	li.highlight {
+		font-weight: bold;
 	}
 	.chart {
 		grid-column-start: 2;
 		grid-column-end: 2;
 		grid-row-start: 1;
 		grid-row-end: span 2;
+	}
+	.next-steps {
+		border: 1px solid var(--charcoal);
+		border-radius: 10px;
+		background-color: var(--cream);
+		padding: 30px;
+		margin-top: 2em;
+	}
+	.next-steps li {
+		line-height: 1.6;
 	}
 	@media screen and (min-width: 900px) {
 		main {

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -7,6 +7,7 @@
 	let { data } = $props();
 	let highlight = $state(0);
 	let intervalId = $state<number>();
+	let chartWidth = $state(500);
 
 	function rotateSelected() {
 		let selected = highlight + 1;
@@ -29,13 +30,16 @@
 
 <main>
 	<h1 class="title">Your Results</h1>
-	<div class="chart">
-		<SpiderChart answers={data.object} {highlight} />
+	<div class="chart" aria-hidden="true" bind:clientWidth={chartWidth}>
+		<SpiderChart answers={data.object} {highlight} {chartWidth} />
 	</div>
 	<div class="results">
 		<ol>
 			{#each dynamics as dynamic, idx}
-				<li class:highlight={idx === highlight}>{dynamic.full}</li>
+				<li class:highlight={idx === highlight}>
+					{dynamic.full}
+					<span class="visually-hidden">Your answer: {data.answers[idx].value} out of 5</span>
+				</li>
 			{/each}
 		</ol>
 		<div class="next-steps">
@@ -65,6 +69,7 @@
 		position: relative;
 		grid-template-columns: 1fr minmax(400px, 1fr);
 		grid-template-rows: min-content 1fr;
+		gap: 1em 3em;
 		background-image: url('$lib/assets/cloud-1.png'), url('$lib/assets/cloud-4.png'),
 			url('$lib/assets/cloud-5.png');
 		background-repeat: no-repeat, no-repeat, no-repeat;


### PR DESCRIPTION
This PR updates the spider chart sizing and responsiveness, and adds an automatic highlight interval. 

**Responsiveness:**
![image](https://github.com/user-attachments/assets/fa589610-41f3-4523-9e8c-62183221f61a)
![image](https://github.com/user-attachments/assets/8aa1b9f2-0215-4176-b1f0-dee4c888c770)
![image](https://github.com/user-attachments/assets/fa5a6787-c251-4d0f-9303-05ce718abce7)

**Next steps**
- Highlight on hover (text or label number)
- Highlighting behavior on mobile (showing a single dynamic instead of the full list)
- Add links and email trigger (or hide that button)
- Add logo to pages
- Add developer attribution
- Swap out font for "light" version, & other updates per design
