### PR TITLE
Sizing + color small changes to match designs

### DIFF
--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -79,8 +79,8 @@
 		width: 100%;
 		display: flex;
 		flex-direction: column;
-		gap: 1.5rem;
-		margin: 1.5rem 0;
+		gap: 10px;
+		margin: 30px 0;
 	}
 
 	.value {
@@ -88,13 +88,16 @@
 		text-align: center;
 		font-weight: 600;
 		color: var(--mustard);
+		margin-bottom: 30px;
+		position: relative;
+		right: 2px;
 	}
 
 	.slider {
 		display: flex;
 		align-items: center;
 		padding: 10px 16px;
-		margin: -14px -20px;
+		margin: -14px -16px;
 		border-radius: 28px;
 		transition: border 0.2s linear;
 		box-sizing: border-box;

--- a/src/lib/components/SpiderChart.svelte
+++ b/src/lib/components/SpiderChart.svelte
@@ -18,7 +18,7 @@
 
 	const config = $derived({
 		d: chartWidth, // diameter of chart
-		labelRadius: 13, // radius of label circles
+		labelRadius: 14, // radius of label circles
 		ticks: [1, 2, 3, 4, 5]
 	});
 
@@ -137,21 +137,15 @@
 					onmouseleave={() => onLeave()}
 					aria-hidden="true"
 				>
-					<circle
-						cx={f.labelX}
-						cy={f.labelY}
-						r={config.labelRadius}
-						stroke="black"
-						stroke-width="1"
-					>
-					</circle>
+					<circle cx={f.labelX} cy={f.labelY} r={config.labelRadius}> </circle>
 					<text x={f.labelX} y={f.labelY}>{idx + 1}</text>
 				</g>
 			{/each}
 		</g>
 		<g id="answer">
 			{#each formattedAnswers as ans}
-				<circle cx={ans.xCoord} cy={ans.yCoord} r={config.labelRadius}></circle>
+				<!-- note: adding 1px to radius to make same size as charcoal circle (with stroke of 1px) -->
+				<circle cx={ans.xCoord} cy={ans.yCoord} r={config.labelRadius + 1}></circle>
 				<text x={ans.xCoord} y={ans.yCoord}>{ans.answer}</text>
 			{/each}
 		</g>
@@ -185,12 +179,14 @@
 		fill: var(--mustard);
 	}
 	#answer text {
-		fill: var(--charcoal);
+		fill: var(--cream);
 	}
 
 	text {
 		/* all <text> elements live inside a circle */
-		transform: translate(-4px, 3px);
+		transform: translate(-5px, 6px);
+		font-weight: 500;
+		font-size: 18px;
 	}
 	/* LABELS */
 	.label text {
@@ -200,9 +196,11 @@
 	.label circle {
 		fill: var(--sky);
 		transition: fill 0.2s linear;
+		stroke: var(--charcoal);
+		stroke-width: 1;
 	}
 	.label.highlight circle {
-		fill: black;
+		fill: var(--charcoal);
 	}
 	.label.highlight text {
 		fill: white;

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -191,4 +191,10 @@
 			margin-bottom: 0px;
 		}
 	}
+
+	@media screen and (max-width: 400px) {
+		main {
+			padding: 10px;
+		}
+	}
 </style>

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -109,10 +109,11 @@
 			bottom 0 right -100px,
 			bottom right;
 		background-size: 485px, 504px, 503px;
+		box-sizing: border-box;
 	}
 	main {
 		position: relative;
-		padding: 3rem;
+		padding: 1rem;
 		grid-template-columns: 1fr minmax(400px, 1fr);
 		grid-template-rows: min-content 1fr;
 		gap: 1em 3em;
@@ -130,6 +131,8 @@
 	h1 {
 		margin: 0;
 		padding: 0;
+		margin-top: 20px;
+		margin-bottom: 40px;
 	}
 	h2 {
 		font-family: 'adobe-garamond-pro', serif;
@@ -178,10 +181,14 @@
 	@media screen and (min-width: 900px) {
 		main {
 			display: grid;
+			padding: 3rem;
 		}
 		.actions {
 			flex-wrap: nowrap;
 			justify-content: flex-start;
+		}
+		h1 {
+			margin-bottom: 0px;
 		}
 	}
 </style>


### PR DESCRIPTION
Just noticed a few places to update styles now that we have all of our pieces coming together. 

- Updates text spacing on the sliders
- Updates circle sizing, colors, and text placement on spider chart
- Decreases horizontal padding on results page on mobile so spider chart doesn't get cut off, adds some vertical spacing according to designs

Mobile results before:

<img width="299" alt="Screenshot 2024-12-17 at 2 45 07 PM" src="https://github.com/user-attachments/assets/e9932746-2377-4791-89f2-7e1d655f3516" />

Mobile results after:

<img width="297" alt="Screenshot 2024-12-17 at 2 45 34 PM" src="https://github.com/user-attachments/assets/fa806502-cb89-4fac-a1d3-6cd62a288623" />


Slider before:

<img width="691" alt="Screenshot 2024-12-17 at 1 17 30 PM" src="https://github.com/user-attachments/assets/fe3e35a5-e402-4775-af5d-b0d457ad3e23" />

Slider after:

<img width="738" alt="Screenshot 2024-12-17 at 1 17 22 PM" src="https://github.com/user-attachments/assets/fc2fe578-c005-4331-8e5d-8c19a9e9d940" />




