### PR TITLE
Add "← retake the quiz" back button to top

### DIFF
--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -50,7 +50,7 @@
 	</header>
 	<main>
 		<div class="intro">
-			<a href="/">← Retake the Quiz</a>
+			<a href="/">← Return to Tool</a>
 			<h1 class="title">Your Results</h1>
 		</div>
 		<div class="chart" aria-hidden="true" bind:clientWidth={chartWidth}>

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -49,7 +49,7 @@
 		<Logo />
 	</header>
 	<main>
-		<div>
+		<div class="intro">
 			<a href="/">← Retake the Quiz</a>
 			<h1 class="title">Your Results</h1>
 		</div>
@@ -136,6 +136,10 @@
 		height: 120px;
 		position: relative;
 	}
+	.intro {
+		margin: 0px 20px;
+		margin-top: 20px;
+	}
 	.chart {
 		grid-column-start: 2;
 		grid-column-end: span 1;
@@ -204,6 +208,9 @@
 		}
 		h1 {
 			margin-bottom: 0px;
+		}
+		.intro {
+			margin: 0px;
 		}
 	}
 

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -49,7 +49,10 @@
 		<Logo />
 	</header>
 	<main>
-		<h1 class="title">Your Results</h1>
+		<div>
+			<a href="/">← Retake the Quiz</a>
+			<h1 class="title">Your Results</h1>
+		</div>
 		<div class="chart" aria-hidden="true" bind:clientWidth={chartWidth}>
 			<SpiderChart answers={data.object} {highlight} {chartWidth} {onHover} onLeave={startRotate} />
 		</div>
@@ -97,6 +100,17 @@
 </div>
 
 <style>
+	a {
+		color: var(--charcoal);
+		font-weight: 600;
+		text-decoration: none;
+		font-style: normal;
+	}
+	a:hover,
+	a:active,
+	a:focus {
+		font-style: italic;
+	}
 	.outer {
 		background-color: var(--sky);
 		min-height: 100vh;
@@ -127,11 +141,12 @@
 		grid-column-end: span 1;
 		grid-row-start: 1;
 		grid-row-end: span 2;
+		margin-top: 40px;
 	}
 	h1 {
 		margin: 0;
 		padding: 0;
-		margin-top: 20px;
+		margin-top: 30px;
 		margin-bottom: 40px;
 	}
 	h2 {
@@ -181,7 +196,7 @@
 	@media screen and (min-width: 900px) {
 		main {
 			display: grid;
-			padding: 3rem;
+			padding: 25px 3rem;
 		}
 		.actions {
 			flex-wrap: nowrap;

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -102,14 +102,15 @@
 <style>
 	a {
 		color: var(--charcoal);
-		font-weight: 600;
+		font-weight: 300;
 		text-decoration: none;
 		font-style: normal;
+		z-index: 1;
 	}
 	a:hover,
 	a:active,
 	a:focus {
-		font-style: italic;
+		font-weight: 500;
 	}
 	.outer {
 		background-color: var(--sky);


### PR DESCRIPTION
Adds a way to get back to the quiz to the page, as currently if a user comes from their email, there's no way to redo the quiz.

I added to the top because I also had felt like it was missing some sort of "back" button after submitting. I accidentally kept clicking the AWCS logo when testing to try to go back, so I think this will help for others like me.

<img width="312" alt="Screenshot 2024-12-18 at 3 26 37 PM" src="https://github.com/user-attachments/assets/9a2d963e-701a-46f9-b60d-a059a6acdfa3" />

<img width="1331" alt="Screenshot 2024-12-18 at 3 24 08 PM" src="https://github.com/user-attachments/assets/08d3838a-4d22-493c-b838-2ce2601c7665" />
