### PR TITLE
change spider chart bg from cream to mustard, half opacity

### DIFF
--- a/src/lib/components/SpiderChart.svelte
+++ b/src/lib/components/SpiderChart.svelte
@@ -173,7 +173,8 @@
 
 	/* ANSWER SHAPES */
 	path.answer {
-		fill: var(--cream);
+		fill: var(--mustard);
+		opacity: 0.5;
 	}
 	#answer circle {
 		fill: var(--mustard);


### PR DESCRIPTION
Change background color of spider chart according to new figma designs

<img width="686" alt="Screenshot 2024-12-18 at 5 10 06 PM" src="https://github.com/user-attachments/assets/e33a8d53-26fd-40d9-9f72-f0d1a2b6ba59" />
