### PR TITLE
Use MailChimp (Mandrill) template

### DIFF
--- a/src/routes/api/email/+server.ts
+++ b/src/routes/api/email/+server.ts
@@ -14,7 +14,7 @@ export async function POST({ request }) {
 			template_content: [
 				{
 					name: 'results_link',
-					content: `https://dreamy-lokum-0293b5.netlify.app/results/${results_string}`
+					content: `Thank you for spending some time with the 8 Dynamics of Climate Engagement! Your results are <a href=${process.env.BASE_URL}/results/${results_string} style="color: #303326; text-decoration: underline">here</a>.`
 				}
 			],
 			message: {

--- a/src/routes/api/email/+server.ts
+++ b/src/routes/api/email/+server.ts
@@ -14,7 +14,7 @@ export async function POST({ request }) {
 			template_content: [
 				{
 					name: 'results_link',
-					content: `Thank you for spending some time with the 8 Dynamics of Climate Engagement! Your results are <a href=${process.env.BASE_URL}/results/${results_string} style="color: #303326; text-decoration: underline">here</a>.`
+					content: `Thank you for spending some time with the 8 Dynamics of Climate Engagement! Your results are <a href="${process.env.BASE_URL}/results/${results_string}" style="color: #303326; text-decoration: underline">here</a>.`
 				}
 			],
 			message: {

--- a/src/routes/api/email/+server.ts
+++ b/src/routes/api/email/+server.ts
@@ -1,29 +1,34 @@
 import mailchimp from '@mailchimp/mailchimp_transactional';
 import { env } from '$env/dynamic/private';
-import dynamics from '$lib/dynamics';
-import type { MessageRecipient } from '@mailchimp/mailchimp_transactional';
 
 const apiKey = env.MAILCHIMP_API_KEY;
 const client = mailchimp(apiKey ?? '');
 
 export async function POST({ request }) {
 	try {
-		const { email, results } = await request.json();
+		const { email, results_string } = await request.json();
 		// todo: include email validation
-		const features = Object.keys(results);
 
 		const message = {
-			to: [{ email, type: 'to' } as MessageRecipient],
-			from_email: 'info@allwecansave.earth',
-			subject: '8 Dynamics - Your Results',
-			html: `<h1>Your Results: </h1>
-				<div>
-				${dynamics.map((d, i) => `<span>${d.short}: ${results[features[i]]}</span>`)}
-				</div>
-			`
+			template_name: 'eight-dynamics',
+			template_content: [
+				{
+					name: 'results_link',
+					content: `https://dreamy-lokum-0293b5.netlify.app/results/${results_string}`
+				}
+			],
+			message: {
+				from_email: 'info@allwecansave.earth',
+				to: [
+					{
+						email: email,
+						name: ''
+					}
+				]
+			}
 		};
 
-		const response = await client.messages.send({ message });
+		const response = await client.messages.sendTemplate(message);
 		if (Array.isArray(response)) {
 			const result = response[0];
 			if (result.status === 'sent') {

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -84,7 +84,7 @@
 					<form
 						onsubmit={async (e) => {
 							e.preventDefault();
-							const resp = await _sendEmail(email, data.object);
+							const resp = await _sendEmail(email, data.results_string);
 							if (resp.success) {
 								alert('Email sent!');
 							} else {

--- a/src/routes/results/[results_string]/+page.ts
+++ b/src/routes/results/[results_string]/+page.ts
@@ -2,7 +2,8 @@ import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
 export function load({ params }: { params: { results_string: string } }) {
-	const matches = [...params.results_string.matchAll(new RegExp(/([a-h])([1-5])/gi))];
+	const { results_string } = params;
+	const matches = [...results_string.matchAll(new RegExp(/([a-h])([1-5])/gi))];
 	if (matches.length !== 8) {
 		error(404, 'invalid match string');
 	}
@@ -15,13 +16,14 @@ export function load({ params }: { params: { results_string: string } }) {
 		object: matches.reduce((prev: Record<string, number>, curr) => {
 			prev[curr[1].toUpperCase()] = parseInt(curr[2], 10);
 			return prev;
-		}, {})
+		}, {}),
+		results_string
 	};
 }
 
 export async function _sendEmail(
 	email: string,
-	results: Record<string, number>
+	results_string: string
 ): Promise<{ success: boolean; message?: string }> {
 	try {
 		const response = await fetch('/api/email', {
@@ -29,7 +31,7 @@ export async function _sendEmail(
 			headers: {
 				'Content-Type': 'application/json'
 			},
-			body: JSON.stringify({ email, results })
+			body: JSON.stringify({ email, results_string })
 		});
 
 		if (!response.ok) {


### PR DESCRIPTION
PR including changes we discussed over our Zoom call earlier this afternoon. We created a template programmatically we now reference by the name "eight-dynamics" and lives in Mandrill (not Mailchimp, to our surprise!). We are now dynamically passing the results link to the email template each time we trigger the email.

The HTML will be defined on the Mandrill platform. More to come there!