### PR TITLE
Simple Analytics: Custom event tracking

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+# https://docs.netlify.com/routing/headers/
+
+Content-Security-Policy: script-src 'self' https://scripts.simpleanalyticscdn.com;

--- a/src/app.html
+++ b/src/app.html
@@ -24,6 +24,7 @@
 	<div style="display: contents">%sveltekit.body%</div>
 	<!-- 100% privacy-first analytics -->
 	<script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+	<script async defer data-collect="outbound" src="https://scripts.simpleanalyticscdn.com/auto-events.js"></script>
 </body>
 
 </html>

--- a/src/lib/components/PromptWithSlider.svelte
+++ b/src/lib/components/PromptWithSlider.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import trackEvent from '$lib/custom-event';
 	import type { Section } from '$lib/types';
 
 	export let value: number;
@@ -50,7 +51,9 @@
 
 	{#if resultsLink}
 		<div class="finish">
-			<a class="btn secondary" href={resultsLink}>Finish</a>
+			<a class="btn secondary" onclick={() => trackEvent('click_finish')} href={resultsLink}>
+				Finish
+			</a>
 		</div>
 	{/if}
 </div>

--- a/src/lib/custom-event.ts
+++ b/src/lib/custom-event.ts
@@ -1,0 +1,6 @@
+export default function trackEvent(eventName: string) {
+	if (!eventName || !window?.sa_event || !window?.sa_loaded) return;
+
+	window.sa_event(eventName);
+	return;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,3 +10,10 @@ export type SectionIllustrations = {
 	left?: string;
 	right?: string;
 };
+
+declare global {
+	interface Window {
+		sa_event: CallableFunction;
+		sa_loaded: boolean;
+	}
+}

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -7,6 +7,7 @@
 	import { onDestroy, onMount } from 'svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import ButtonLoader from '$lib/components/ButtonLoader.svelte';
+	import trackEvent from '$lib/custom-event';
 
 	const INTERVAL = 1500;
 	const BREAKPOINT = 900;
@@ -59,6 +60,7 @@
 
 	function openModal(): void {
 		showEmailModal = true;
+		trackEvent('click_send_email');
 	}
 
 	function closeModal(): void {
@@ -146,7 +148,7 @@
 	</header>
 	<main>
 		<div class="intro fade-in">
-			<a href="/">← Retake the Quiz</a>
+			<a onclick={() => trackEvent('click_retake_quiz')} href="/">← Retake the Quiz</a>
 			<h1 class="title">Your Results</h1>
 		</div>
 		<div class="chart fade-in delayed" aria-hidden="true" bind:clientWidth={chartWidth}>

--- a/src/routes/results/[results_string]/+page.svelte
+++ b/src/routes/results/[results_string]/+page.svelte
@@ -60,7 +60,7 @@
 
 	function openModal(): void {
 		showEmailModal = true;
-		trackEvent('click_send_email');
+		trackEvent('click_email_prompt');
 	}
 
 	function closeModal(): void {
@@ -96,6 +96,7 @@
 							sendEmailFinished = true;
 							sendEmailSuccess = resp.success;
 							email = '';
+							trackEvent('click_email_send_success');
 						}
 					}
 				}}


### PR DESCRIPTION
Adds the ability to track [custom events](https://docs.simpleanalytics.com/automated-events). We are currently tracking:

- `click_finish` - how many people clicked the "finish" button on the home page
- `click_email_prompt` - how many people clicked the "Email Your Results" button
- `click_email_send_success` - how many people entered their email and successfully triggered a send
- `click_retake_quiz` - how many people clicked the "Retake the quiz" button
- all external link clicks